### PR TITLE
Add `project get` command

### DIFF
--- a/cmd/constants/constants.go
+++ b/cmd/constants/constants.go
@@ -2,4 +2,5 @@ package constants
 
 const (
 	HarborCredentialName = "HARBORCREDENTIALNAME"
+	CredentialNameOption = "credential-name"
 )

--- a/cmd/project/get_project.go
+++ b/cmd/project/get_project.go
@@ -1,0 +1,48 @@
+package project
+
+import (
+	"context"
+
+	"github.com/akshatdalton/harbor-cli/cmd/constants"
+	"github.com/akshatdalton/harbor-cli/cmd/utils"
+	"github.com/goharbor/go-client/pkg/sdk/v2.0/client/project"
+	"github.com/spf13/cobra"
+)
+
+type getProjectOptions struct {
+	projectNameOrID string
+}
+
+// NewGetProjectCommand creates a new `harbor get project` command
+func NewGetProjectCommand() *cobra.Command {
+	var opts getProjectOptions
+
+	cmd := &cobra.Command{
+		Use:   "project [NAME|ID]",
+		Short: "get project by name or id",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.projectNameOrID = args[0]
+			credentialName, err := cmd.Flags().GetString(constants.CredentialNameOption)
+			if err != nil {
+				return err
+			}
+			return runGetProject(opts, credentialName)
+		},
+	}
+
+	return cmd
+}
+
+func runGetProject(opts getProjectOptions, credentialName string) error {
+	client := utils.GetClientByCredentialName(credentialName)
+	ctx := context.Background()
+	response, err := client.Project.GetProject(ctx, &project.GetProjectParams{ProjectNameOrID: opts.projectNameOrID})
+
+	if err != nil {
+		return err
+	}
+
+	utils.PrintPayloadInJSONFormat(response)
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,28 @@
 package cmd
 
 import (
+	"github.com/akshatdalton/harbor-cli/cmd/constants"
 	"github.com/akshatdalton/harbor-cli/cmd/login"
+	"github.com/akshatdalton/harbor-cli/cmd/project"
 	"github.com/spf13/cobra"
 )
 
+// newGetCommand creates a new `harbor get` command
+func newGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get [COMMAND]",
+		Short: "get project, registry, etc.",
+		Long:  `Get project, registry`,
+	}
+
+	cmd.PersistentFlags().String(constants.CredentialNameOption, "", "Name of the credential to use for authentication")
+	cmd.AddCommand(project.NewGetProjectCommand())
+	return cmd
+}
+
 func addCommands(cmd *cobra.Command) {
 	cmd.AddCommand(login.NewLoginCommand())
+	cmd.AddCommand(newGetCommand())
 }
 
 // CreateHarborCLI creates a new Harbor CLI


### PR DESCRIPTION
This commit adds the project get command for the
user to get the project by name or ID.

This PR depends on: #1.